### PR TITLE
SQL Feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - nightly
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "type": "library",
   "license": "BSD-3-Clause",
   "require": {
-    "php": ">=5.3",
+    "php": ">=5.4",
     "phpoffice/phpexcel": "1.8.0",
     "gajus/dindent": "2.0.*"
   },

--- a/tests/DataFrame/SQL/SQLDataFrameExceptionTest.php
+++ b/tests/DataFrame/SQL/SQLDataFrameExceptionTest.php
@@ -13,7 +13,9 @@ class SQLDataFrameExceptionTest extends \PHPUnit_Framework_TestCase
 
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec("CREATE TABLE testTable (a TEXT NOT NULL, b TEXT, c TEXT);");
+        $pdo->exec("CREATE TABLE testTable (a TEXT NOT NULL,
+b TEXT,
+c TEXT);");
 
         // The NOT NULL constraint on column a is what we'll be using to trigger a rollback.
 

--- a/tests/DataFrame/SQL/SQLDataFrameExceptionTest.php
+++ b/tests/DataFrame/SQL/SQLDataFrameExceptionTest.php
@@ -57,8 +57,7 @@ class SQLDataFrameExceptionTest extends \PHPUnit_Framework_TestCase
             /*
              * Now that the exception has been asserted, we make sure the data in
              * the database still matches what we originally committed from the
-             * first valid dataframe. This is a perfect use case for the finally
-             * keyword, but it is only supported in PHP 5.5 and later.
+             * first valid dataframe.
              */
             $query = $pdo->query("SELECT * FROM testTable;");
             $result = $query->fetchAll(PDO::FETCH_ASSOC);

--- a/tests/DataFrame/SQL/SQLDataFrameExceptionTest.php
+++ b/tests/DataFrame/SQL/SQLDataFrameExceptionTest.php
@@ -13,9 +13,7 @@ class SQLDataFrameExceptionTest extends \PHPUnit_Framework_TestCase
 
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec("CREATE TABLE testTable (a TEXT NOT NULL,
-b TEXT,
-c TEXT);");
+        $pdo->exec("CREATE TABLE testTable (a TEXT NOT NULL, b TEXT, c TEXT);");
 
         // The NOT NULL constraint on column a is what we'll be using to trigger a rollback.
 

--- a/tests/DataFrame/SQL/SQLDataFrameExceptionTest.php
+++ b/tests/DataFrame/SQL/SQLDataFrameExceptionTest.php
@@ -46,6 +46,15 @@ class SQLDataFrameExceptionTest extends \PHPUnit_Framework_TestCase
             $bad->toSQL($pdo, 'testTable', ['chunksize' => 1]);
         } catch (PDOException $e) {
             /*
+             * We throw the original exception back here so that we can perform one
+             * more assertion in the finally block.
+             *
+             * If we didn't do this then PHPUnit would terminate as soon as the
+             * expected exception was detected.
+             */
+            throw $e;
+        } finally {
+            /*
              * Now that the exception has been asserted, we make sure the data in
              * the database still matches what we originally committed from the
              * first valid dataframe. This is a perfect use case for the finally
@@ -56,15 +65,6 @@ class SQLDataFrameExceptionTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($result, $good->toArray());
 
             $pdo->exec("DROP TABLE testTable;");
-
-            /*
-             * We throw the original exception back here so that we can perform one
-             * more assertion in the finally block.
-             *
-             * If we didn't do this then PHPUnit would terminate as soon as the
-             * expected exception was detected.
-             */
-            throw $e;
         }
     }
 }

--- a/tests/DataFrame/SQL/SQLDataFrameUnitTest.php
+++ b/tests/DataFrame/SQL/SQLDataFrameUnitTest.php
@@ -15,7 +15,9 @@ class SQLDataFrameUnitTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $pdo = new PDO('sqlite::memory:');
-        $pdo->exec("CREATE TABLE testTable (a TEXT, b TEXT, c TEXT);");
+        $pdo->exec("CREATE TABLE testTable (a TEXT,
+b TEXT,
+c TEXT);");
         $df->toSQL($pdo, 'testTable');
         $query = $pdo->query("SELECT * FROM testTable;");
         $result = $query->fetchAll(PDO::FETCH_ASSOC);

--- a/tests/DataFrame/SQL/SQLDataFrameUnitTest.php
+++ b/tests/DataFrame/SQL/SQLDataFrameUnitTest.php
@@ -15,9 +15,8 @@ class SQLDataFrameUnitTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $pdo = new PDO('sqlite::memory:');
-        $pdo->exec("CREATE TABLE testTable (a TEXT,
-b TEXT,
-c TEXT);");
+
+        $pdo->exec("CREATE TABLE testTable (a TEXT, b TEXT, c TEXT);");
         $df->toSQL($pdo, 'testTable');
         $query = $pdo->query("SELECT * FROM testTable;");
         $result = $query->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
Removed support for PHP 5.4 due to the lack of the finally keyword, and lack of support for SQLite multi-value insert statements.

Included the ability to commit an instance of DataFrame to a relational database, given an instance of PDO and an existing table to commit it to.